### PR TITLE
Fixed 403: User not authorised for ses:SendEmail function

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ provider:
     - Effect: "Allow"
       Action:
         - "sqs:SendMessage"
+        - "ses:SendEmail"
       Resource: "*"
     - Effect: "Allow"
       Action:


### PR DESCRIPTION
Every time I was trying to CC a response, this error would crop up
```
message: "User `arn:aws:sts::{ID}:assumed-role/{service}-{stage}-{region}-lambdaRole/{service}-{stage}-receive' is not authorized to perform `ses:SendEmail' on resource `arn:aws:ses:{region}:{ID}:identity/{verified_email}'"
statusCode: 403
```

I did a little bit of digging and [found][1] that someone mentioned that the `ses:SendEmail` permission needs to be added for that to work. I added it and voila, it works!

[1]: https://forum.serverless.com/t/access-denied-for-ses-sendmail/3059