### PR TITLE
Update `isWebsite` validation to use a URL parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,6 +1341,14 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fast-check": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.6.1.tgz",
+      "integrity": "sha512-CauHEKfAjgAFpNDpFqSccu7C5kOlifCNfRxMjzY76MaAaH7ddkqqEzRE2Vm5bjpHJpndD0iVXiZC+d1rYzv5qg==",
+      "requires": {
+        "pure-rand": "^3.0.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -2916,6 +2924,11 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "pure-rand": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-3.1.0.tgz",
+      "integrity": "sha512-xkCSMNjEnLG/A8iTH9M5ayXN4SCWRP+ih3rxi09Q7Fu0b9jAP6V9H59pOtcB37IsVt3eHxf1FMy9n7YrqdDdSA=="
     },
     "qs": {
       "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "aws-sdk": "^2.28.0",
-    "fast-check": "^2.6.1",
     "request": "^2.88.0"
   },
   "devDependencies": {
@@ -21,6 +20,7 @@
     "eslint-plugin-node": "^4.2.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^2.1.1",
+    "fast-check": "^2.6.1",
     "mocha": "^6.2.0",
     "serverless-plugin-include-dependencies": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.28.0",
+    "fast-check": "^2.6.1",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -6,7 +6,7 @@ module.exports.isWebsite = string => {
     return VALID_WEBSITE_SCHEMES.has(parsed.protocol)
   } catch (e) {
     // Keeping the regex validation as a fallback to avoid
-    // a backwards-incompatible behavior change.
+    // a backwards-incompatible behavior change for incomplete URLs.
     return /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.test(string)
   }
 }

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -1,5 +1,12 @@
 module.exports.isWebsite = string => {
-  return /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.test(string)
+  try {
+    new URL(string);
+    return true;
+  } catch (e) {
+    // Keeping the regex validation as a fallback to avoid
+    // a backwards-incompatible behavior change.
+    return /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.test(string)
+  }
 }
 
 module.exports.isEmail = string => {

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -1,7 +1,9 @@
+const VALID_WEBSITE_SCHEMES = new Set(['http:', 'https:'])
+
 module.exports.isWebsite = string => {
   try {
-    new URL(string)
-    return true
+    const parsed = new URL(string)
+    return VALID_WEBSITE_SCHEMES.has(parsed.protocol)
   } catch (e) {
     // Keeping the regex validation as a fallback to avoid
     // a backwards-incompatible behavior change.

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -1,7 +1,7 @@
 module.exports.isWebsite = string => {
   try {
-    new URL(string);
-    return true;
+    new URL(string)
+    return true
   } catch (e) {
     // Keeping the regex validation as a fallback to avoid
     // a backwards-incompatible behavior change.

--- a/src/lib/validation.spec.js
+++ b/src/lib/validation.spec.js
@@ -1,5 +1,6 @@
 const describe = require('mocha').describe
 const it = require('mocha').it
+const assert = require('chai').assert
 const fc = require('fast-check')
 
 const validation = require('./validation')
@@ -31,5 +32,11 @@ describe('validation', function () {
         }
       )
     )
+  })
+
+  it("should accept partial (host/path only) URLs of certain known forms", function () {
+    assert.isTrue(validation.isWebsite('google.com'))
+    assert.isTrue(validation.isWebsite('www.google.com'))
+    assert.isTrue(validation.isWebsite('www.google.com/search?q=url'))
   })
 })

--- a/src/lib/validation.spec.js
+++ b/src/lib/validation.spec.js
@@ -1,6 +1,5 @@
 const describe = require('mocha').describe
 const it = require('mocha').it
-const assert = require('chai').assert
 const fc = require('fast-check')
 
 const validation = require('./validation')

--- a/src/lib/validation.spec.js
+++ b/src/lib/validation.spec.js
@@ -1,0 +1,36 @@
+const describe = require('mocha').describe
+const it = require('mocha').it
+const assert = require('chai').assert
+const fc = require('fast-check')
+
+const validation = require('./validation')
+
+describe('validation', function () {
+  it("should accept any valid http(s) URL", function () {
+    fc.assert(
+      fc.property(
+        fc.webUrl({
+          validSchemes: ['http', 'https'],
+          withFragments: true,
+          withQueryParameters: true
+        }),
+        function (url) {
+          return validation.isWebsite(url)
+        }
+      )
+    )
+  })
+
+  it("should reject any valid non-http(s) URL", function () {
+    fc.assert(
+      fc.property(
+        fc.webUrl({
+          validSchemes: ['ftp', 'gopher', 'file']
+        }),
+        function (url) {
+          return !validation.isWebsite(url)
+        }
+      )
+    )
+  })
+})


### PR DESCRIPTION
Fixes danielireson/formplug-serverless#25

Validating URLs is most correctly done with a URL parser, though regexes
can be made to do the trick sometimes. Rather than making the regex even
gnarlier to read though, I'm proposing here to just use the `URL` class
provided by node and try a parse.

This falls back to the previous regex as some previously-accepted
incomplete URLs (e.g. `host.com/no/scheme/provided`) don't parse as
URLs and it would be undesirable to reject such values if folks have
come to depend on their being accepted.

## TODO
- [x] More comprehensive tests on URL validation